### PR TITLE
Add publications section to homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,15 @@
 ---
 layout: default.liquid
 title: Bolun Thompson
+publications:
+  - year: 2026
+    title: "hS: Speculative Script Reordering at Subprocess Granularity"
+    authors: "Georgios Liargkovas, Di Jin, Tianyu Zhu, Dan Liu, <u>A. Bolun Thompson</u>, Anirudh Narsipur, Seong-Heon Jung, Siddhartha Prasad, Diomidis Spinellis, Michael Greenberg, Konstantinos Kallas, Nikos Vasilakis"
+    venue: "OSDI '26"
+  - year: 2026
+    title: "Pync: Function Level Incremental Execution for Python Scripts"
+    authors: "<u>A. Bolun Thompson</u>"
+    venue: "PLDI 2026 Student Research Competition"
 ---
 
 ## About Me
@@ -24,7 +33,12 @@ Feel free to get in touch at my email: me [at] bolun [dot] dev!
 ## Publications
 
 <div class="card-list">
-Coming soon :)
+
+{% for pub in page.publications -%}
+- **{{ pub.year }}** — **{{ pub.title }}.**  
+  {{ pub.authors }}. *{{ pub.venue }}*.
+{% endfor %}
+
 </div>
 
 ## Education


### PR DESCRIPTION
## Summary
Updated the homepage to display a list of publications instead of a placeholder message. Publications are now managed as structured data in the front matter and rendered dynamically.

## Key Changes
- Added `publications` array to the page front matter with two entries:
  - "hS: Speculative Script Reordering at Subprocess Granularity" (OSDI '26)
  - "Pync: Function Level Incremental Execution for Python Scripts" (PLDI 2026 Student Research Competition)
- Replaced the "Coming soon :)" placeholder with a Liquid template loop that iterates over publications and renders them in a consistent format
- Each publication displays year, title, authors (with the author's name underlined), and venue

## Implementation Details
- Publications are stored as YAML front matter, making them easy to maintain and update
- The template uses Liquid's `for` loop to dynamically generate publication entries
- Author names are wrapped in HTML `<u>` tags for emphasis
- The rendering format follows: `**Year** — **Title.** Authors. *Venue*.`

https://claude.ai/code/session_01UaBdcHv8naomuSXhsoQNoE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a publications section to the homepage driven by front matter data, replacing the placeholder. Entries render dynamically via a Liquid loop for easy updates.

- **New Features**
  - Added a `publications` array in the page front matter with two entries (OSDI ’26, PLDI 2026 SRC).
  - Replaced "Coming soon" with a Liquid for-loop that renders year, title, authors (author name underlined), and venue.
  - Future updates require adding a single record to the front matter.

<sup>Written for commit 64d37f8939ae23b3d983e1022e0890079896045b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

