### PR TITLE
Add publications section to home page

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,15 +1,16 @@
 ---
 layout: default.liquid
 title: Bolun Thompson
-publications:
-  - year: 2026
-    title: "hS: Speculative Script Reordering at Subprocess Granularity"
-    authors: "Georgios Liargkovas, Di Jin, Tianyu Zhu, Dan Liu, <u>A. Bolun Thompson</u>, Anirudh Narsipur, Seong-Heon Jung, Siddhartha Prasad, Diomidis Spinellis, Michael Greenberg, Konstantinos Kallas, Nikos Vasilakis"
-    venue: "OSDI '26"
-  - year: 2026
-    title: "Pync: Function Level Incremental Execution for Python Scripts"
-    authors: "<u>A. Bolun Thompson</u>"
-    venue: "PLDI 2026 Student Research Competition"
+data:
+  publications:
+    - year: 2026
+      title: "hS: Speculative Script Reordering at Subprocess Granularity"
+      authors: "Georgios Liargkovas, Di Jin, Tianyu Zhu, Dan Liu, <u>A. Bolun Thompson</u>, Anirudh Narsipur, Seong-Heon Jung, Siddhartha Prasad, Diomidis Spinellis, Michael Greenberg, Konstantinos Kallas, Nikos Vasilakis"
+      venue: "OSDI '26"
+    - year: 2026
+      title: "Pync: Function Level Incremental Execution for Python Scripts"
+      authors: "<u>A. Bolun Thompson</u>"
+      venue: "PLDI 2026 Student Research Competition"
 ---
 
 ## About Me
@@ -34,7 +35,7 @@ Feel free to get in touch at my email: me [at] bolun [dot] dev!
 
 <div class="card-list">
 
-{% for pub in page.publications -%}
+{% for pub in page.data.publications -%}
 - **{{ pub.year }}** — **{{ pub.title }}.**  
   {{ pub.authors }}. *{{ pub.venue }}*.
 {% endfor %}


### PR DESCRIPTION
Replace the "Coming soon" placeholder with a Liquid-templated list driven by structured frontmatter under `data:`, so future publications can be added by appending a single record.

https://claude.ai/code/session_01UaBdcHv8naomuSXhsoQNoE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the “Coming soon” placeholder with a dynamic publications list on the home page. The list is rendered with Liquid and sourced from `data.publications` front matter, so adding new items only requires appending a record.

<sup>Written for commit 4e5369bed3fd11bdaf3dc041471ad2f4ac5d7e9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

